### PR TITLE
Add Programming Phoenix LiveView book

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ If you think a new resource should be added, please file an issue or even better
 
 - [Phoenix LiveView Examples](https://tefter.io/zorbash/lists/phoenix-liveview-examples) - A curated list of examples, demos, guides and tutorials
 
+## Books
+
+- [Programming Phoenix LiveView](https://pragprog.com/titles/liveview/programming-phoenix-liveview/) - Interactive Elixir Web Programming Without Writing Any JavaScript by Bruce A. Tate and Sophie DeBenedetto
+
 # Contributing
 
 Contributions are most welcome!


### PR DESCRIPTION
I have added a new `Books` headline and the following book to the end of the `README.md`:

[Programming Phoenix LiveView](https://pragprog.com/titles/liveview/programming-phoenix-liveview/)